### PR TITLE
[MATC-121] New Google translate API `model` service support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "google/apiclient-services",
+    "name": "gyg/google-apiclient-services",
     "type": "library",
     "description": "Client library for Google APIs",
     "keywords": ["google"],

--- a/src/Google/Service/Translate.php
+++ b/src/Google/Service/Translate.php
@@ -44,7 +44,7 @@ class Google_Service_Translate extends Google_Service
   public function __construct(Google_Client $client)
   {
     parent::__construct($client);
-    $this->rootUrl = 'https://www.googleapis.com/';
+    $this->rootUrl = 'https://translation.googleapis.com/';
     $this->servicePath = 'language/translate/';
     $this->version = 'v2';
     $this->serviceName = 'translate';
@@ -120,6 +120,10 @@ class Google_Service_Translate extends Google_Service
                   'type' => 'string',
                 ),
                 'source' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
+                'model' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),


### PR DESCRIPTION
Setting up `model` service that is required with google NMT.